### PR TITLE
Python 3.9 compatibility fix

### DIFF
--- a/hyphen/dictools.py
+++ b/hyphen/dictools.py
@@ -240,16 +240,16 @@ def parse_dictionary_location(descr_file, origin_url, language):
         # record
         locales = []
         dict_location = None
-        for prop in node.getchildren():
+        for prop in list(node):
             for _pk, pv in prop.items():
                 if pv.lower() == 'locations':
                     # Its only child's text is a list of strings of the form %origin%<filename>
                     # For simplicity, we only use the first filename in the
                     # list.
-                    dict_location = prop.getchildren()[0].text.split()[0]
+                    dict_location = list(prop)[0].text.split()[0]
                 elif pv.lower() == 'locales':
                     # Its only child's text is a list of locales.
-                    locales = prop.getchildren()[0].text.replace(
+                    locales = list(prop)[0].text.replace(
                         '-', '_').split()
                     # break # skip any other values of this property
         if language in locales and dict_location:

--- a/hyphen/dictools.py
+++ b/hyphen/dictools.py
@@ -16,7 +16,7 @@ __all__ = ['install', 'is_installed', 'uninstall', 'list_installed']
 
 
 DEFAULT_DICT_PATH = appdirs.user_data_dir("pyhyphen", appauthor=False)
-DEFAULT_REPOSITORY = 'http://cgit.freedesktop.org/libreoffice/dictionaries/plain/'
+DEFAULT_REPOSITORY = 'https://cgit.freedesktop.org/libreoffice/dictionaries/plain/'
 # This is a list of languages supported by PyHyphen. In the following, language
 # codes are assumed to be in this list.
 LANGUAGES = ['af_ZA', 'an_ES', 'ar', 'be_BY', 'bg_BG', 'bn_BD', 'br_FR', 'ca',

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ arg_dict = dict(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: C',
         'Topic :: Text Processing',
         'Topic :: Text Processing :: Linguistic'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py35,py36,py37,py38
+envlist = py27,py35,py36,py37,py38,py39
 
 [testenv]
 deps = pytest


### PR DESCRIPTION
In Python 3.9, node.getchildren() was removed. We can replace the same functionality with list(node) instead (sesrch for `getchildren` in https://docs.python.org/3.9/whatsnew/3.9.html). I’m not a Python expert, but this seems to work and now passes the unit tests in tox, which I’ve updated to include Python 3.9.

I’ve also pointed the freedesktop.org URL to the https protocol; the server is just redirecting anyway, so this should be slightly faster.

I’ve tested this locally and it works fine, both creating the pyhyphen directory and downloading the appropriate dictionaries, and hyphenating the file I threw at it without problems.