### PR TITLE
textwrap2: Correctly hyphenate overly long words

### DIFF
--- a/src/hyphen/textwrap2.py
+++ b/src/hyphen/textwrap2.py
@@ -41,6 +41,7 @@ class TextWrapper(textwrap.TextWrapper):
             # cur_len is just the length of all the chunks in cur_line.
             cur_line = []
             cur_len = 0
+            hyphenated_last = False
 
             # Figure out which static string will prefix this line.
             if lines:
@@ -72,11 +73,12 @@ class TextWrapper(textwrap.TextWrapper):
                         if hyphenated_chunk:
                             cur_line.append(hyphenated_chunk[0])
                             chunks[-1] = hyphenated_chunk[1]
+                            hyphenated_last = True
                     break
 
             # The current line is full, and the next chunk is too big to
             # fit on *any* line (not just this one).
-            if chunks and len(chunks[-1]) > width:
+            if chunks and len(chunks[-1]) > width and not hyphenated_last:
                 self._handle_long_word(chunks, cur_line, cur_len, width)
                 cur_len = sum(map(len, cur_line))
 

--- a/test/test_textwrap2.py
+++ b/test/test_textwrap2.py
@@ -16,3 +16,21 @@ class TestTextwrap2(unittest.TestCase):
 beauty is
 a joy for-
 ever.""", wrapped)
+
+    def test_long_word_fill(self):
+        hyphenator = hyphen.Hyphenator("en_US")
+        wrapped = textwrap2.fill("Some incomprehensibilities might come up.",
+                                 width=12, use_hyphenator=hyphenator)
+        self.assertEqual("""Some incom-
+prehensibil-
+ities might
+come up.""", wrapped)
+
+    def test_long_unbreakable_fill(self):
+        hyphenator = hyphen.Hyphenator("en_US")
+        wrapped = textwrap2.fill("Some xxxxxxxxxxxxxxxxxxxxx might come up.",
+                                 width=12, use_hyphenator=hyphenator)
+        self.assertEqual("""Some xxxxxxx
+xxxxxxxxxxxx
+xx might
+come up.""", wrapped)


### PR DESCRIPTION
The case where a word needed to be hyphenated more than once for the
text to fit within the text width was not handled correctly: after the
first hyphenation, the remained would still be longer than the maximum
line length and the remainder would be forcibly broken up; due to
cur_len not being updated when the first part is added to the line, the
resulting line would then be malformed.

With this commit, a chunk is only forcibly broken up when the last chunk
had not been hyphenated. Other solutions, e.g. only breaking a chunk
when it is the first of its line, lead to behaviour for long
un-hyphen-able text inconsistent with the standard library’s textwrap.

A unit test for both a natural word and an unbreakable string too long
to fit on a line is added as well.

Fixes #11.